### PR TITLE
WETH9.sol -> WEVMOS9.sol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Canonical W-EVMOS
+
+This is the official repository for the canonical Wrapped Evmos token -- deployed to Evmos Mainnet. 
+
+It has been forked from the official canonical-weth project which can be read about [here](https://blog.0xproject.com/canonical-weth-a9aa7d0279dd). 
+
+*The remainder of this readme has been left in its original form below:*
+
 # Canonical W-ETH
 
 Canonical [W-ETH](https://weth.io/) package (see https://blog.0xproject.com/canonical-weth-a9aa7d0279dd)

--- a/contracts/WEVMOS9.sol
+++ b/contracts/WEVMOS9.sol
@@ -15,9 +15,9 @@
 
 pragma solidity >=0.4.22 <0.6;
 
-contract WETH9 {
-    string public name     = "Wrapped Ether";
-    string public symbol   = "WETH";
+contract WEVMOS9 {
+    string public name     = "Wrapped Evmos";
+    string public symbol   = "WEVMOS";
     uint8  public decimals = 18;
 
     event  Approval(address indexed src, address indexed guy, uint wad);


### PR DESCRIPTION
Edited the `WETH9.sol` contract to become `WEVMOS9.sol`, added a brief note in `README.md` noting the distinction and origin of this package. 